### PR TITLE
Bump to latest version to 1.80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM unidata/tomcat-docker:8
 MAINTAINER Kyle Wilcox <kyle@axiomdatascience.com>
 
-ENV ERDDAP_VERSION 1.78
+ENV ERDDAP_VERSION 1.80
 ENV ERDDAP_CONTENT_URL http://coastwatch.pfeg.noaa.gov/erddap/download/erddapContent.zip
 #ENV ERDDAP_CONTENT_URL http://coastwatch.pfeg.noaa.gov/erddap/download/erddapContent$ERDDAP_VERSION.zip
 ENV ERDDAP_WAR_URL https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddap.war

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A feature full Tomcat (SSL over APR, etc.) running [ERDDAP](http://coastwatch.pf
 
 Available versions:
 
+* `axiom/docker-erddap:1.80`
 * `axiom/docker-erddap:1.78`
 * `axiom/docker-erddap:1.74` - first release based on `unidata/tomcat-docker`
 * `axiom/docker-erddap:1.72`


### PR DESCRIPTION
Simple change to latest ERDDAP version 1.80.  Tested on macOS 10.12.6 and Ubuntu 16.04.3 but not on Windows.