### PR TITLE
Pin the underlying Tomcat image by hash to increase reproducability.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM unidata/tomcat-docker:8.5
+FROM unidata/tomcat-docker:8.5@sha256:1a5fb1b4407075613c2d8aea0b23b25a10733ffe755e367b1d4dfc8f96249023
 LABEL maintainer="Kyle Wilcox <kyle@axiomdatascience.com>"
 
 ENV ERDDAP_VERSION 2.10

--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ Available versions:
 
 See all versions available [here](https://hub.docker.com/r/axiom/docker-erddap/tags). As always, consult the [ERDDAP Changes](https://coastwatch.pfeg.noaa.gov/erddap/download/changes.html) documentation before upgrading your sever.
 
-The [upstream image](https://github.com/Unidata/tomcat-docker) this project uses replaces tagged images with new images periodcally. Even for release tags.
-This makes it impossible for a downsteam project like this to maintain a reliable build process. At any point the upstream image may overwrite the base image
-this repository uses with one that does not. It has happened at least 3 times so far. If you find a bug in any of the versions above please
-[report it as an issue](https://github.com/axiom-data-science/docker-erddap/issues).
+The [upstream image](https://github.com/Unidata/tomcat-docker) this project uses replaces tagged images with new images periodically. Even for release tags.
 This repository will **not** back-port changes from the upstream image to existing tags and overwrite them. If you require features from a newer upstream image
 (for example - SHA512 password hashes) you will have to wait for the next ERDDAP release which will be built with the newest upstream image.
 You can also build this image yourself.


### PR DESCRIPTION
By pinning the underlying Tomcat image by hash in addition to by tag, reproducibility of builds can be improved. While a tag may pointed to a new image, the hash will follow the same image.

This way even if Unidata decides to update an existing tag on `unidata/tomcat-docker` then using the new version in `axiom/docker-erddap` requires an explicit change.

To manually check to see if the hash should be updated, you can run `docker rmi unidata/tomcat-docker:8.5` to remove the existing image, then run a `pull` to get the latest hash.
```sh
➜ docker pull unidata/tomcat-docker:8.5
8.5: Pulling from unidata/tomcat-docker
Digest: sha256:1a5fb1b4407075613c2d8aea0b23b25a10733ffe755e367b1d4dfc8f96249023
Status: Downloaded newer image for unidata/tomcat-docker:8.5
docker.io/unidata/tomcat-docker:8.5
```
This process could also be automated with PRs from Dependabot.