### PR TITLE
Use Dependabot to check that the base image is up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,59 @@
+name: Push
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    name: Build and test Docker Image
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Cache Docker Layers
+      uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
+    
+    - name: Login to Docker Hub
+      uses: azure/docker-login@v1
+      continue-on-error: true
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    
+    - name: Build Docker Image
+      run: docker build --tag axiom/docker-erddap:latest .
+
+    - name: Run Docker Image in Background
+      run: docker run -d -p 8080:8080 axiom/docker-erddap:latest
+
+    - name: Check that ERDDAP Docker Image will return a 200
+      uses: ifaxity/wait-on-action@v1
+      timeout-minutes: 1
+      with:
+        resource: http://localhost:8080/erddap/index.html
+    
+  push:
+    name: Push latest image to Docker Hub
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    needs: build
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && github.repository == 'axiom-data-science/docker-erddap'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Cache Docker Layers
+      uses: satackey/action-docker-layer-caching@v0.0.11
+    
+    - name: Login to Docker Hub
+      uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    
+    - name: Push latest image to Docker Hub if on master or main branch of Axiom's repo
+      run: docker push axiom/docker-erddap:latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This repository will **not** back-port changes from the upstream image to existi
 (for example - SHA512 password hashes) you will have to wait for the next ERDDAP release which will be built with the newest upstream image.
 You can also build this image yourself.
 
+Use `latest` image with caution as it follows the upstream image, and is not as thoroughly tested as tagged images.
+
+[Dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically) is used to automatically make PRs to update the upstream image ([`.github/dependabot.yml`](.github/dependabot.yml)).
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
Extends #18 with Dependabot checking the base image to make sure it is up to date weekly.

Additionally it adds Github Actions to check each push to the repo to make sure the image can be build, launched, and will return a 200 from the default ERDDAP page.

When a commit is to the main or master branch in Axiom's repo, Github Actions will  then push the latest image to Docker Hub. (This requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets to be setup in the repo, which will also be used to authenticate pulling of Docker images to avoid rate limiting)