### PR TITLE
Adding support to inject the memory to allocate as per #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,17 @@ See [these instructions for configuring Tomcat](https://github.com/unidata/tomca
     ```
 
     This is **highly** recommended, or nothing will persist across container restarts (logs/cache/etc.)
+
+
+3.  Specify the amount of memory to be allocated:
+
+   ``` bash
+
+    $ docker run \
+        --env ERDDAP_MIN_MEMORY=4G --env ERDDAP_MAX_MEMORY=8G
+        ... \
+        axiom/docker-erddap
+   ```
+
+   Note that both environment variables will fall back to a single ERDDAP_MEMORY variable, which in turn falls back to 4G by default.
+

--- a/files/setenv.sh
+++ b/files/setenv.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # JAVA_OPTS
-MEMORY="4G"
-NORMAL="-server -d64 -Xms$MEMORY -Xmx$MEMORY"
+MEMORY="${ERDDAP_MEMORY:-4G}"
+NORMAL="-server -d64 -Xms${ERDDAP_MIN_MEMORY:-${MEMORY}} -Xmx${ERDDAP_MAX_MEMORY:-${MEMORY}}"
 HEAP_DUMP="-XX:+HeapDumpOnOutOfMemoryError"
 HEADLESS="-Djava.awt.headless=true"
 EXTRAS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled"


### PR DESCRIPTION
As suggested in #28 this change allows to specify the memory (both initial and max) of the Java-heap-size to run the tomcat/erddap webapp.