### PR TITLE
Use a docker build arg for the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM unidata/tomcat-docker:8.5@sha256:0d65eef935da7bc00242360269070261fb6e6428cb906aa4ce7509301a2216f9
+ARG BASE_IMAGE=unidata/tomcat-docker:8.5@sha256:0d65eef935da7bc00242360269070261fb6e6428cb906aa4ce7509301a2216f9
+FROM ${BASE_IMAGE}
 LABEL maintainer="Kyle Wilcox <kyle@axiomdatascience.com>"
 
 ENV ERDDAP_VERSION 2.18

--- a/files/setenv.sh
+++ b/files/setenv.sh
@@ -14,7 +14,7 @@ fi
 
 # JAVA_OPTS
 MEMORY="${ERDDAP_MEMORY:-4G}"
-NORMAL="-server -d64 -Xms${ERDDAP_MIN_MEMORY:-${MEMORY}} -Xmx${ERDDAP_MAX_MEMORY:-${MEMORY}}"
+NORMAL="-server -Xms${ERDDAP_MIN_MEMORY:-${MEMORY}} -Xmx${ERDDAP_MAX_MEMORY:-${MEMORY}}"
 HEAP_DUMP="-XX:+HeapDumpOnOutOfMemoryError"
 HEADLESS="-Djava.awt.headless=true"
 EXTRAS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled"


### PR DESCRIPTION
Make the Docker base image configurable at build time
using a build arg. This makes it easier to build images
based on various base images (e.g. unidata/tomcat-docker:8.5-jdk11-openjdk):

docker build --build-arg BASE_IMAGE=unidata/tomcat-docker:8.5-jdk11-openjdk -t docker-erddap-jdk11 .