### PR TITLE
Add /init.d script/executable init on container startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,3 +243,25 @@ Example:
 ```
 ERDDAP_DATASETS_cacheMinutes=20 ./datasets.d.sh examples/datasets.d
 ```
+
+#### Initialization scripts (/init.d) - EXPERIMENTAL
+
+Additional configuration can be performed by placing executable files and/or
+shell scripts in `/init.d`. These executables will be run on every container
+start up, so they __must be idempotent__. This functionality is inspired by
+the postgres Docker image's
+[`/docker-entrypoint-initdb.d`](https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts).
+
+Example:
+
+```
+#remove .hdf and .nc files from range request exclusion
+mkdir -p init.d
+cat << 'EOF' > init.d/10-remove-hdf-nc-range-request-exclusion.sh
+sed -i 's/.hdf, .nc, //g' ${CATALINA_HOME}/webapps/erddap/WEB-INF/classes/gov/noaa/pfel/erddap/util/messages.xml
+EOF
+
+chmod +x init.d/10-remove-hdf-nc-range-request-exclusion.sh
+
+docker run -d -p 8080:8080 -v $(pwd)/init.d:/init.d:ro --name erddap axiom/docker-erddap
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,24 @@ if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
       /datasets.d.sh > "$DATASETS_XML"
     fi
 
+    ###
+    # Run executables/shell scripts in /init.d on each container startup
+    # Inspired by postgres' /docker-entrypoint-initdb.d
+    # https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts
+    # https://github.com/docker-library/postgres/blob/master/docker-entrypoint.sh#L156
+    ###
+    if [ -d "/init.d" ]; then
+      for f in /init.d/*; do
+        if [ -x "$f" ]; then
+          echo "Executing $f"
+          "$f"
+        elif [[ $f == *.sh ]]; then
+          echo "Sourcing $f (not executable)"
+          . "$f"
+        fi
+      done
+    fi
+
     exec gosu tomcat "$@"
 fi
 

--- a/init.d/10-remove-hdf-nc-range-request-exclusion.sh
+++ b/init.d/10-remove-hdf-nc-range-request-exclusion.sh
@@ -1,0 +1,1 @@
+sed -i 's/.hdf, .nc, //g' ${CATALINA_HOME}/webapps/erddap/WEB-INF/classes/gov/noaa/pfel/erddap/util/messages.xml


### PR DESCRIPTION
Inspired by postgres container's /docker-entrypoint-initdb.d

https://github.com/docker-library/docs/blob/master/postgres/README.md#initialization-scripts

Allows for tinkering without overriding entrypoint.sh or Dockerfile
or adding extensive env var switches