### PR TITLE
Add more build args for custom builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@ ARG BASE_IMAGE=unidata/tomcat-docker:8.5@sha256:0d65eef935da7bc00242360269070261
 FROM ${BASE_IMAGE}
 LABEL maintainer="Kyle Wilcox <kyle@axiomdatascience.com>"
 
-ENV ERDDAP_VERSION 2.18
-ENV ERDDAP_CONTENT_URL https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddapContent.zip
-ENV ERDDAP_WAR_URL https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddap.war
+ARG ERDDAP_VERSION=2.18
+ARG ERDDAP_CONTENT_URL=https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddapContent.zip
+ARG ERDDAP_WAR_URL=https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddap.war
 ENV ERDDAP_bigParentDirectory /erddapData
 
-RUN apt-get update && apt-get install -y xmlstarlet \
+RUN apt-get update && apt-get install -y unzip xmlstarlet \
+    && if ! command -v gosu &> /dev/null; then apt-get install -y gosu; fi \
     && rm -rf /var/lib/apt/lists/*
 
+ARG BUST_CACHE=1
 RUN \
     curl -fSL "${ERDDAP_CONTENT_URL}" -o /erddapContent.zip && \
     unzip /erddapContent.zip -d ${CATALINA_HOME} && \

--- a/files/setenv.sh
+++ b/files/setenv.sh
@@ -12,12 +12,20 @@ if [ -n "$ERDDAP_CONFIG" ]; then
     echo -e "ERDDAP configured with:\n$ERDDAP_CONFIG"
 fi
 
+JAVA_MAJOR_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
+
 # JAVA_OPTS
 MEMORY="${ERDDAP_MEMORY:-4G}"
 NORMAL="-server -Xms${ERDDAP_MIN_MEMORY:-${MEMORY}} -Xmx${ERDDAP_MAX_MEMORY:-${MEMORY}}"
 HEAP_DUMP="-XX:+HeapDumpOnOutOfMemoryError"
 HEADLESS="-Djava.awt.headless=true"
-EXTRAS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled"
+
+EXTRAS=${JAVA_EXTRAS:-}
+if [ $JAVA_MAJOR_VERSION -lt 9 ]; then
+  #these options are deprecated in java 9 and illegal in java 14+
+  EXTRAS="$EXTRAS -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled"
+fi
+
 CONTENT_ROOT="-DerddapContentDirectory=$CATALINA_HOME/content/erddap"
 JNA_DIR="-Djna.tmpdir=/tmp/"
 FASTBOOT="-Djava.security.egd=file:/dev/./urandom"


### PR DESCRIPTION
Convert some Dockerfile ENVs to ARGs so they can be set at build time using --build-arg.

Also don't set illegal/invalid JVM options for recent JVMs.