### PR TITLE
Build multiple Docker hub images for older Docker compatibility

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,6 +23,8 @@ jobs:
         include:
           - tag: "jdk17-openjdk"
             base: "unidata/tomcat-docker:10.1.0-jdk17-openjdk@sha256:8b595bcd8eee410e2d610829b5d4e312d51e3ea6c6bde952a5838845f67a4839"
+          - tag: "jdk17-temurin-focal"
+            base: "unidata/tomcat-docker:10.1.0-jdk17-temurin-focal@sha256:99c083fd17d1f8d6c85a0f771039ffb4d2430ff7fd6dabea8eb50f2731328af8"
 
     steps:
     - name: Checkout
@@ -89,6 +91,8 @@ jobs:
         include:
           - tag: "jdk17-openjdk"
             base: "unidata/tomcat-docker:10.1.0-jdk17-openjdk@sha256:8b595bcd8eee410e2d610829b5d4e312d51e3ea6c6bde952a5838845f67a4839"
+          - tag: "jdk17-temurin-focal"
+            base: "unidata/tomcat-docker:10.1.0-jdk17-temurin-focal@sha256:99c083fd17d1f8d6c85a0f771039ffb4d2430ff7fd6dabea8eb50f2731328af8"
 
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=unidata/tomcat-docker:10.1.0-jdk17-temurin-focal@sha256:99c083fd17d1f8d6c85a0f771039ffb4d2430ff7fd6dabea8eb50f2731328af8
+ARG BASE_IMAGE=unidata/tomcat-docker:10.1.0-jdk17-openjdk@sha256:8b595bcd8eee410e2d610829b5d4e312d51e3ea6c6bde952a5838845f67a4839
 FROM ${BASE_IMAGE}
 LABEL maintainer="Kyle Wilcox <kyle@axiomdatascience.com>"
 


### PR DESCRIPTION
We should build (at least) two Docker hub images, one based on `unidata/tomcat-docker:10.1.0-jdk17-openjdk`
and another based on `unidata/tomcat-docker:10.1.0-jdk17-temurin-focal` which is compatible with older Docker versions.

https://github.com/docker-library/tomcat/issues/269