### PR TITLE
Add arm64/v8 build, inherit from tomcat, upgrade to tomcat 10.1.16

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,13 +23,13 @@ jobs:
       matrix:
         include:
           #amd64
-          - tag: "jdk17-openjdk"
+          - platform: "linux/amd64"
+            tag: "jdk17-openjdk"
             base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:5d06ae2052b1a4c636454e65360a712fd262eebf574f8a97f37c2580edce7d46"
-            platform: "linux/amd64"
           #arm64/v8
-          - tag: "jdk17-openjdk"
+          - platform: "linux/arm64/v8"
+            tag: "jdk17-openjdk"
             base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:7d930ac5ba9091aa12c1a42e3cc7c59c12c8d032e076c3713c10bb9b35227b5d"
-            platform: "linux/arm64/v8"
 
     steps:
     - name: Checkout
@@ -91,13 +91,13 @@ jobs:
       matrix:
         include:
           #amd64
-          - tag: "jdk17-openjdk"
+          - platform: "linux/amd64"
+            tag: "jdk17-openjdk"
             base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:5d06ae2052b1a4c636454e65360a712fd262eebf574f8a97f37c2580edce7d46"
-            platform: "linux/amd64"
           #arm64/v8
-          - tag: "jdk17-openjdk"
+          - platform: "linux/arm64/v8"
+            tag: "jdk17-openjdk"
             base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:7d930ac5ba9091aa12c1a42e3cc7c59c12c8d032e076c3713c10bb9b35227b5d"
-            platform: "linux/arm64/v8"
 
     steps:
     - name: Checkout

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,12 +19,17 @@ jobs:
     timeout-minutes: 10
 
     strategy:
+      #NOTE: make sure to replicate this matrix config in the push job below
       matrix:
         include:
+          #amd64
           - tag: "jdk17-openjdk"
-            base: "unidata/tomcat-docker:10.1.0-jdk17-openjdk@sha256:8b595bcd8eee410e2d610829b5d4e312d51e3ea6c6bde952a5838845f67a4839"
-          - tag: "jdk17-temurin-focal"
-            base: "unidata/tomcat-docker:10.1.0-jdk17-temurin-focal@sha256:99c083fd17d1f8d6c85a0f771039ffb4d2430ff7fd6dabea8eb50f2731328af8"
+            base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:5d06ae2052b1a4c636454e65360a712fd262eebf574f8a97f37c2580edce7d46"
+            platform: "linux/amd64"
+          #arm64/v8
+          - tag: "jdk17-openjdk"
+            base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:7d930ac5ba9091aa12c1a42e3cc7c59c12c8d032e076c3713c10bb9b35227b5d"
+            platform: "linux/arm64/v8"
 
     steps:
     - name: Checkout
@@ -51,17 +56,11 @@ jobs:
         restore-keys: |
           ${ CACHE_KEY }
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
-      continue-on-error: true
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Build and push
+    - name: Build image
       uses: docker/build-push-action@v2
       with:
         push: false
+        platforms: ${{ matrix.platform }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -71,9 +70,11 @@ jobs:
         outputs: type=docker
 
     - name: Run Docker Image in Background
+      if: matrix.platform == 'linux/amd64'
       run: docker run -d -p 8080:8080 ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
 
     - name: Check that ERDDAP Docker Image will return a 200
+      if: matrix.platform == 'linux/amd64'
       uses: ifaxity/wait-on-action@v1
       timeout-minutes: 1
       with:
@@ -89,10 +90,14 @@ jobs:
     strategy:
       matrix:
         include:
+          #amd64
           - tag: "jdk17-openjdk"
-            base: "unidata/tomcat-docker:10.1.0-jdk17-openjdk@sha256:8b595bcd8eee410e2d610829b5d4e312d51e3ea6c6bde952a5838845f67a4839"
-          - tag: "jdk17-temurin-focal"
-            base: "unidata/tomcat-docker:10.1.0-jdk17-temurin-focal@sha256:99c083fd17d1f8d6c85a0f771039ffb4d2430ff7fd6dabea8eb50f2731328af8"
+            base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:5d06ae2052b1a4c636454e65360a712fd262eebf574f8a97f37c2580edce7d46"
+            platform: "linux/amd64"
+          #arm64/v8
+          - tag: "jdk17-openjdk"
+            base: "tomcat:10.1.16-jdk17-temurin-jammy@sha256:7d930ac5ba9091aa12c1a42e3cc7c59c12c8d032e076c3713c10bb9b35227b5d"
+            platform: "linux/arm64/v8"
 
     steps:
     - name: Checkout
@@ -129,6 +134,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
+        platforms: ${{ matrix.platform }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ RUN apt-get update && \
     sed -i 's/UMASK.*022/UMASK           007/g' /etc/login.defs
 
 # Security enhanced web.xml
-#COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/web.xml ${CATALINA_HOME}/conf/
+COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/web.xml ${CATALINA_HOME}/conf/
 
 # Security enhanced server.xml
-#COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/
+COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/
 
 ARG ERDDAP_VERSION=2.23
 ARG ERDDAP_CONTENT_URL=https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddapContent.zip

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Most recent versions:
 * `axiom/docker-erddap:latest-jdk17-openjdk` (2.23)
 * `axiom/docker-erddap:2.23-jdk17-openjdk`
 
-See all versions available [here](https://hub.docker.com/r/axiom/docker-erddap/tags). As always, consult the [ERDDAP Changes](https://coastwatch.pfeg.noaa.gov/erddap/download/changes.html) documentation before upgrading your sever.
-
-The [upstream image](https://github.com/Unidata/tomcat-docker) this project uses replaces tagged images with new images periodically. Even for release tags. This repository will **not** back-port changes from the upstream image to existing tags and overwrite them. If you require features from a newer upstream image (for example - SHA512 password hashes) you will have to wait for the next ERDDAP release which will be built with the newest upstream image. You can also build this image yourself.
+See all versions available [here](https://hub.docker.com/r/axiom/docker-erddap/tags). As always, consult the [ERDDAP Changes](https://coastwatch.pfeg.noaa.gov/erddap/download/changes.html) documentation before upgrading your server.
 
 Use any of the `latest-*` images with caution as they follow the upstream image, and is not as thoroughly tested as tagged images.
 
@@ -44,11 +42,11 @@ later customization
 
 ### Tomcat
 
-See [these instructions for configuring Tomcat](https://github.com/unidata/tomcat-docker) from the Tomcat image this is built from (`unidata/tomcat-docker`).
+See [these instructions for configuring Tomcat](https://github.com/unidata/tomcat-docker) from the Tomcat image this image borrows from (`unidata/tomcat-docker`).
 
 ### CORS
 
-The [Tomcat Docker image](https://github.com/unidata/tomcat-docker) used by this image enables the
+The [Tomcat configuration](https://github.com/unidata/tomcat-docker) used by this image enables the
 [Apache Tomcat CORS filter](https://tomcat.apache.org/tomcat-8.5-doc/config/filter.html#CORS_Filter) by
 default. To disable it (maybe you want to handle CORS uniformly in a proxying webserver?), set environment
 variable `DISABLE_CORS` to `1`.


### PR DESCRIPTION
Upgrade to Tomcat 10.1.16. Change Dockerfile to use `tomcat` base image directly, allowing for more freedom over upstream tomcat versions and platforms. Copy hardened web.xml and server.xml from Unidata/tomcat-docker (these are just text files so they can be reused across platforms).

Add arm64/v8 builds. Fixes #69.

Also, drop support for temurin-focal based images (not available for Tomcat 10).