### PR TITLE
Update tomcat from 10.1.16 to 10.1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=tomcat:10.1.16-jdk17-temurin-jammy
+ARG BASE_IMAGE=tomcat:10.1.19-jdk17-temurin-jammy
 #referencing a specific image digest pins our unidata tomcat-docker image to platform amd64 (good)
 ARG UNIDATA_TOMCAT_IMAGE=unidata/tomcat-docker:10-jdk17@sha256:af7d3fecec753cbd438f25881deeaf48b40ac1f105971d6f300252e104e39fb2
 FROM ${UNIDATA_TOMCAT_IMAGE} as unidata-tomcat-image
@@ -40,8 +40,8 @@ COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/web.xml ${CATALINA_HOME}/
 COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/
 
 ARG ERDDAP_VERSION=2.23
-ARG ERDDAP_CONTENT_URL=https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddapContent.zip
-ARG ERDDAP_WAR_URL=https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddap.war
+ARG ERDDAP_CONTENT_URL=https://github.com/ERDDAP/erddap/releases/download/v$ERDDAP_VERSION/erddapContent.zip
+ARG ERDDAP_WAR_URL=https://github.com/ERDDAP/erddap/releases/download/v$ERDDAP_VERSION/erddap.war
 ENV ERDDAP_bigParentDirectory /erddapData
 
 RUN apt-get update && apt-get install -y unzip xmlstarlet \


### PR DESCRIPTION
REF: https://groups.google.com/g/erddap/c/eVnQK44lNNA

Two new high-level CVEs were just issued for Tomcat (CVE-2024-24549 & CVE-2024-23672). Please make sure you are running the latest version.

Dockerfile:
 * Update tomcat from 10.1.16 to 10.1.19
 * Use ERDDAP repo release url