### PR TITLE
fix ip address in logs when running reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/web.xml ${CATALINA_HOME}/
 # Security enhanced server.xml
 COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/
 
+# Enable request attributes so that, when using a reverse proxy, the original
+# client ip is recorded in logs rather than the internal proxy ip
+RUN  sed -i 's/className="org.apache.catalina.valves.AccessLogValve"/className="org.apache.catalina.valves.AccessLogValve" requestAttributesEnabled="true"/g' ${CATALINA_HOME}/conf/server.xml
+
 ARG ERDDAP_VERSION=2.23
 ARG ERDDAP_CONTENT_URL=https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddapContent.zip
 ARG ERDDAP_WAR_URL=https://github.com/BobSimons/erddap/releases/download/v$ERDDAP_VERSION/erddap.war


### PR DESCRIPTION
When running a reverse proxy in front of ERDDAP (e.g. nginx, load balancer etc.) the ip address recorded in the tomcat log files is an the internal proxy ip address, not the ip address of the client.

This PR adds `requestAttributesEnabled="true"` to `AccessLogValve` in `server.xml` after it is copied from the unidata tomcat image.

I don't *think* this should break anything, but definitely want to test this one out before merging. I have not previously worked with reverse proxies and request headers.

Solution first posted in the ERDDAP google group https://groups.google.com/g/erddap/c/8UUUSwavsvA/m/23-ClxdbAgAJ