### PR TITLE
 fix ip address in logs with requestAttributesEnable

### DIFF
--- a/update-server-xml.sh
+++ b/update-server-xml.sh
@@ -38,7 +38,7 @@ set_attribute /Server/Service/Connector relaxedQueryChars "$RELAXED_QUERY_CHARS"
 
 # Enable request attributes so that, when using a reverse proxy, the original
 # client ip is recorded in logs rather than the internal proxy ip
-set_attribute  /Server/Service/Engine/Host/Valve requestAttributesEnable "true"
+set_attribute /Server/Service/Engine/Host/Valve requestAttributesEnable "true"
 
 #create RemoteIpValve if missing. this is needed so ERDDAP knows when its responding to https requests
 #end result should look like:

--- a/update-server-xml.sh
+++ b/update-server-xml.sh
@@ -36,6 +36,10 @@ function set_attribute {
 set_attribute /Server/Service/Connector relaxedPathChars "$RELAXED_PATH_CHARS"
 set_attribute /Server/Service/Connector relaxedQueryChars "$RELAXED_QUERY_CHARS"
 
+# Enable request attributes so that, when using a reverse proxy, the original
+# client ip is recorded in logs rather than the internal proxy ip
+set_attribute  /Server/Service/Engine/Host/Valve requestAttributesEnable "true"
+
 #create RemoteIpValve if missing. this is needed so ERDDAP knows when its responding to https requests
 #end result should look like:
 #<Valve className="org.apache.catalina.valves.RemoteIpValve"


### PR DESCRIPTION
This is an alternative to PR #76 

I have moved the command that adds requestAttributesEnable to `update-server-xml.sh`, using the xml edit function available in that script