### PR TITLE
bump to 2.25.1

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -11,6 +11,8 @@ on:
 env:
   BUILDX_CACHE: /tmp/.buildx-cache
   CACHE_KEY: docker-erddap-buildx-
+  TOMCAT_AMD64_IMAGE: tomcat:10.1.26-jdk21-temurin-jammy@sha256:18952effb643bf192799e4ab2ca7c121d58871e96e5709fb5d405f4682a9aae7
+  TOMCAT_ARM64_IMAGE: tomcat:10.1.26-jdk21-temurin-jammy@sha256:4775c2227f16ee2726a35a1e97f43bfcb1a085cad23e169b1066ec9603826d8b
 
 jobs:
   build:
@@ -24,11 +26,11 @@ jobs:
           #amd64
           - platform: "linux/amd64"
             tag: "${{ vars.DOCKER_TAG }}"
-            base: "${{ vars.TOMCAT_AMD64_IMAGE }}"
+            base: "${{ TOMCAT_AMD64_IMAGE }}"
           #arm64/v8
           - platform: "linux/arm64/v8"
             tag: "${{ vars.DOCKER_TAG }}"
-            base: "${{ vars.TOMCAT_ARM64_IMAGE }}"
+            base: "${{ TOMCAT_ARM64_IMAGE }}"
 
     steps:
     - name: Checkout
@@ -92,11 +94,11 @@ jobs:
           #amd64
           - platform: "linux/amd64"
             tag: "${{ vars.DOCKER_TAG }}"
-            base: "${{ vars.TOMCAT_AMD64_IMAGE }}"
+            base: "${{ TOMCAT_AMD64_IMAGE }}"
           #arm64/v8
           - platform: "linux/arm64/v8"
             tag: "${{ vars.DOCKER_TAG }}"
-            base: "${{ vars.TOMCAT_ARM64_IMAGE }}"
+            base: "${{ TOMCAT_ARM64_IMAGE }}"
 
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,10 @@ COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/web.xml ${CATALINA_HOME}/
 # Security enhanced server.xml
 COPY --from=unidata-tomcat-image ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/
 
-ARG ERDDAP_VERSION=2.24
-ARG ERDDAP_CONTENT_URL=https://github.com/ERDDAP/erddap/releases/download/v$ERDDAP_VERSION/erddapContent.zip
-ARG ERDDAP_WAR_URL=https://github.com/ERDDAP/erddap/releases/download/v$ERDDAP_VERSION/erddap.war
+ARG ERDDAP_VERSION=2.25.1
+ARG ERDDAP_CONTENT_VERSION=1.0.0
+ARG ERDDAP_CONTENT_URL="https://github.com/ERDDAP/erddapContent/archive/refs/tags/content${ERDDAP_CONTENT_VERSION}.zip"
+ARG ERDDAP_WAR_URL="https://github.com/ERDDAP/erddap/releases/download/v${ERDDAP_VERSION}/erddap.war"
 ENV ERDDAP_bigParentDirectory /erddapData
 
 RUN apt-get update && apt-get install -y unzip xmlstarlet \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A feature full Tomcat (SSL over APR, etc.) running [ERDDAP](http://coastwatch.pf
 
 Most recent versions:
 
-* `axiom/docker-erddap:latest-jdk21-openjdk` (2.24)
+* `axiom/docker-erddap:latest-jdk21-openjdk` (2.25.1)
+* `axiom/docker-erddap:2.25.1-jdk21-openjdk`
 * `axiom/docker-erddap:2.24-jdk21-openjdk`
 * `axiom/docker-erddap:2.23-jdk17-openjdk`
 


### PR DESCRIPTION
@srstsavage not sure if I got it right. Feel free to close it if you want to do this in a different way and/or later.

I'd love to address https://github.com/axiom-data-science/docker-erddap/issues/90 in this PR. just not sure the best way to implement that.

2.25 is marked as a pre-release, let's keep it a draft for now.

Closes https://github.com/axiom-data-science/docker-erddap/issues/94 and https://github.com/axiom-data-science/docker-erddap/issues/95.